### PR TITLE
Fix path traversal in untar_file via tar member validation

### DIFF
--- a/clipped/clipped/utils/paths.py
+++ b/clipped/clipped/utils/paths.py
@@ -221,8 +221,15 @@ def untar_file(
         extract_path = os.path.join(extract_path, filename.split(".tar.gz")[0])
     check_or_create_path(extract_path, is_dir=True)
     _logger.info("Untarring the content of the file ...")
-    # Untar the file
+    # Untar the file with path traversal protection
+    abs_extract = os.path.abspath(extract_path)
     with tarfile.open(filename) as tar:
+        for member in tar.getmembers():
+            member_path = os.path.abspath(os.path.join(abs_extract, member.name))
+            if not member_path.startswith(abs_extract + os.sep) and member_path != abs_extract:
+                raise ValueError(
+                    "Attempted path traversal in tar archive: {}".format(member.name)
+                )
         tar.extractall(extract_path)
     if delete_tar:
         _logger.info("Cleaning up the tar file ...")

--- a/clipped/tests/test_path_utils.py
+++ b/clipped/tests/test_path_utils.py
@@ -11,6 +11,7 @@ from clipped.utils.paths import (
     delete_old_files,
     get_files_by_paths,
     get_files_in_path_context,
+    untar_file,
 )
 
 
@@ -128,3 +129,36 @@ class TestFiles(TestCase):
         assert deleted_count == 0
         assert deleted_files == []
         assert os.path.exists(fpath1)
+
+    def test_untar_file_normal(self):
+        """Test that normal tar extraction works."""
+        dirname = tempfile.mkdtemp()
+        tar_path = os.path.join(dirname, "test.tar.gz")
+        with tarfile.open(tar_path, "w:gz") as tar:
+            info = tarfile.TarInfo(name="hello.txt")
+            data = b"hello world"
+            info.size = len(data)
+            import io
+            tar.addfile(info, io.BytesIO(data))
+
+        extract_dir = os.path.join(dirname, "out")
+        os.makedirs(extract_dir)
+        untar_file(tar_path, extract_path=extract_dir, use_filepath=False)
+        assert os.path.exists(os.path.join(extract_dir, "hello.txt"))
+
+    def test_untar_file_rejects_path_traversal(self):
+        """Regression test: tar entries with ../ must be rejected."""
+        dirname = tempfile.mkdtemp()
+        tar_path = os.path.join(dirname, "evil.tar.gz")
+        with tarfile.open(tar_path, "w:gz") as tar:
+            info = tarfile.TarInfo(name="../../etc/evil.txt")
+            data = b"path traversal"
+            info.size = len(data)
+            import io
+            tar.addfile(info, io.BytesIO(data))
+
+        extract_dir = os.path.join(dirname, "out")
+        os.makedirs(extract_dir)
+        with self.assertRaises(ValueError) as ctx:
+            untar_file(tar_path, extract_path=extract_dir, use_filepath=False, delete_tar=False)
+        assert "path traversal" in str(ctx.exception).lower()


### PR DESCRIPTION
`tarfile.extractall()` in `untar_file` was called without validating member paths. A crafted tar archive with entries like `../../etc/evil` can write files outside the intended extraction directory.

This adds validation that checks each tar member's resolved absolute path stays within the extraction directory before extracting. Raises `ValueError` on traversal attempts.

Includes regression tests for both normal extraction and path traversal rejection.